### PR TITLE
Release111

### DIFF
--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -332,7 +332,7 @@ class ReceiptDataProvider
             $this->currentOrder->setState(Recurring::ORDER_STATE_CUSTOM_CODE);
             $this->currentOrder->setStatus(Recurring::ORDER_STATUS_CUSTOM_CODE);
             $this->currentOrder->addCommentToStatusHistory(__('Pending payment from Paytrail Payment Service'));
-        } else {
+        } elseif (!($this->currentOrder->getStatus() === 'processing' && $this->currentOrder->getTotalPaid())) {
             $this->currentOrder->setState($orderState)->setStatus($orderState);
             $this->currentOrder->addCommentToStatusHistory(__('Payment has been completed'));
         }

--- a/i18n/fi_FI.csv
+++ b/i18n/fi_FI.csv
@@ -63,6 +63,11 @@ Discount,Alennus
 Shipping,Toimitus
 "Restore a canceled order","Palauta peruutettu tilaus"
 "Restore order #","Palauta tilaus #"
+Hello,Hei
+"Restore order <a href=""%order_url"">%order_increment</a>","Palauta tilaus #<a href=""%order_url"">%order_increment</a>"
+"The payment for the order %order_increment has been completed while the order was in canceled state.
+        Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock.","Tilaukselle #%order_increment saapui maksu tilauksen peruuttamisen jälkeen
+        Pyydämme teitä tarkastamaan kyseisen tilauksen tilan Magenton administa ja käyttämään 'Restore order' toimintoa"
 "The payment for the order #","Maksu tilaukselle #"
 " has been completed while the order was in canceled state. "," on hyväksytty tilauksen ollessa peruutettu tilassa. "
 "Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock.", "Ole hyvä, ja valitse kyseinen tilaus Magenton hallinnassa ja klikkaa Palauta tilaus. Huomioi varastosaldo."

--- a/view/frontend/email/restore_order_notification.html
+++ b/view/frontend/email/restore_order_notification.html
@@ -1,10 +1,27 @@
 <!--@subject {{trans "Restore a canceled order"}} @-->
+<!-- @vars {
+"var order.increment":"order increment",
+"var order.url":"order adminurl"
+} @-->
 
 {{template config_path="design/email/header_template"}}
 
-<h3>{{trans "Restore order #" + var data.order_id|raw}}</h3>
+<h3>{{trans "Hello"}}</h3>
+<h3>
+    {{trans
+        'Restore order <a href="%order_url">%order_increment</a>'
 
-<p>{{trans "The payment for the order #" + var data.order_id|raw + " has been completed while the order was in canceled state. " +
-    "Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock."}}</p>
+        order_url=$order.url
+        order_increment=$order.increment
+    |raw}}
+</h3>
+<p>
+    {{trans
+        "The payment for the order %order_increment has been completed while the order was in canceled state.
+        Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock."
+
+        order_increment=$order.increment
+    |raw}}
+</p>
 
 {{template config_path="design/email/footer_template"}}


### PR DESCRIPTION
Release111 internal review before customer.

Contains changes done by @bartoszkaluzny-solteq  rolled into single pull request with couple of changes.
- Cleaned up nested if statements in line 335 turning else { if   into elseif { statement 
- rewrote the email template, testing revealed that the template translations did not function.
- email url now fetched from backend url interface instead of frontend url interface.
- Template variables embedded directly into the template without using data classes.

When using html inside the translation notice the |raw}} declaration at the end of each translation.