### PR TITLE
SQMAGOPC-392 Create a link to last order in admin subscription grid.

### DIFF
--- a/Ui/Component/Listing/Column/RecurringAction.php
+++ b/Ui/Component/Listing/Column/RecurringAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paytrail\PaymentService\Ui\Component\Listing\Column;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+/**
+ * Class ViewAction for Listing Column
+ */
+class RecurringAction extends Column
+{
+    /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
+     * Constructor
+     *
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param UrlInterface $urlBuilder
+     * @param array $components
+     * @param array $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        UrlInterface $urlBuilder,
+        array $components = [],
+        array $data = []
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    /**
+     * Prepare Theme Data Source
+     *
+     * @param array $dataSource
+     * @return array
+     */
+    public function prepareDataSource(array $dataSource) : array
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as & $item) {
+                $indexField = $this->getData('config/indexField') ?: 'entity_id';
+                if (isset($item[$indexField])) {
+                    $viewUrlPath = $this->getData('config/viewUrlPath') ?: '#';
+                    $urlEntityParamName = $this->getData('config/urlEntityParamName') ?: 'id';
+                    $item[$this->getData('name')] = [
+                        'view' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                $viewUrlPath,
+                                [
+                                    $urlEntityParamName => $item[$indexField]
+                                ]
+                            ),
+                            'label' => __('View'),
+                        ]
+                    ];
+                    $item[$this->getData('name')]['view_order'] = [
+                        'href' => $this->urlBuilder->getUrl(
+                            'sales/order/view',
+                            [
+                                'order_id' => $item['last_order_id']
+                            ]
+                        ),
+                        'label' => __('View last Order'),
+                    ];
+                }
+            }
+        }
+
+        return $dataSource;
+    }
+}

--- a/Ui/DataProvider/RecurringPayment.php
+++ b/Ui/DataProvider/RecurringPayment.php
@@ -2,18 +2,21 @@
 
 namespace Paytrail\PaymentService\Ui\DataProvider;
 
+use Magento\Backend\Model\UrlInterface;
+use Paytrail\PaymentService\Model\ResourceModel\Subscription\CollectionFactory;
+
 class RecurringPayment extends \Magento\Ui\DataProvider\AbstractDataProvider
 {
-    /** @var \Paytrail\PaymentService\Model\ResourceModel\Subscription\CollectionFactory */
+    /** @var CollectionFactory */
     private $collectionFactory;
 
     public function __construct(
-                                                                        $name,
-                                                                        $primaryFieldName,
-                                                                        $requestFieldName,
-        \Paytrail\PaymentService\Model\ResourceModel\Subscription\CollectionFactory $collectionFactory,
-        array                                                           $meta = [],
-        array                                                           $data = []
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        CollectionFactory $collectionFactory,
+        array $meta = [],
+        array $data = []
     ) {
         parent::__construct(
             $name,
@@ -42,7 +45,15 @@ class RecurringPayment extends \Magento\Ui\DataProvider\AbstractDataProvider
                     ['cu' => 'customer_entity'],
                     'main_table.customer_id = cu.entity_id',
                     ['cu.email']
-                );
+                )->join(
+                    ['sublink' => 'paytrail_subscription_link'],
+                    'main_table.entity_id = sublink.subscription_id',
+                    ['last_order_id' => 'MAX(sublink.order_id)']
+                )->join(
+                    ['profile' => 'recurring_payment_profiles'],
+                    'main_table.recurring_profile_id = profile.profile_id',
+                    ['profile_name' => 'profile.name']
+                )->group('main_table.entity_id');
         }
 
         return $this->collection;

--- a/view/adminhtml/ui_component/recurring_payments_listing.xml
+++ b/view/adminhtml/ui_component/recurring_payments_listing.xml
@@ -116,6 +116,21 @@
                 <filter>text</filter>
                 <bodyTmpl>ui/grid/cells/text</bodyTmpl>
                 <label translate="true">Profile id</label>
+                <visible>false</visible>
+            </settings>
+        </column>
+        <column name="profile_name">
+            <settings>
+                <filter>text</filter>
+                <bodyTmpl>ui/grid/cells/text</bodyTmpl>
+                <label translate="true">Profile Name</label>
+            </settings>
+        </column>
+        <column name="last_order_id">
+            <settings>
+                <filter>text</filter>
+                <bodyTmpl>ui/grid/cells/text</bodyTmpl>
+                <label translate="true">Last Order id</label>
             </settings>
         </column>
         <column name="updated_at" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
@@ -123,6 +138,7 @@
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <label translate="true">Updated at</label>
+                <visible>false</visible>
             </settings>
         </column>
         <column name="end_date" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date">
@@ -130,6 +146,7 @@
                 <filter>dateRange</filter>
                 <dataType>date</dataType>
                 <label translate="true">End date</label>
+                <visible>false</visible>
             </settings>
         </column>
         <column name="repeat_count_left">
@@ -137,6 +154,7 @@
                 <filter>text</filter>
                 <bodyTmpl>ui/grid/cells/text</bodyTmpl>
                 <label translate="true">Repeats left</label>
+                <visible>false</visible>
             </settings>
         </column>
         <column name="retry_count">
@@ -144,6 +162,7 @@
                 <filter>text</filter>
                 <bodyTmpl>ui/grid/cells/text</bodyTmpl>
                 <label translate="true">Retries left</label>
+                <visible>false</visible>
             </settings>
         </column>
         <column name="email">
@@ -153,7 +172,7 @@
                 <label translate="true">Customer Email</label>
             </settings>
         </column>
-        <actionsColumn name="actions" class="Magento\Theme\Ui\Component\Listing\Column\ViewAction" sortOrder="50">
+        <actionsColumn name="actions" class="Paytrail\PaymentService\Ui\Component\Listing\Column\RecurringAction" sortOrder="50">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="viewUrlPath" xsi:type="string">recurring_payments/recurring/view</item>


### PR DESCRIPTION
Branch cleans up the admin Subscription grid for recurring payment.
Changes:

- It hides several unused columns (end date, retry count & error count)
- Change profile id column to be profile name instead making the grid easier to read.
- Add last order id column which shows the ID number of the last order belonging to the given subscription.
- Change "view" action column to a dropdown in the grid that allows the admin user to either view the subscription or last order belonging to the subscription.