### PR TITLE
Catch exceptions during order cancellation

### DIFF
--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -559,7 +559,7 @@ class ReceiptDataProvider
                 ));
 
                 // Mask and throw end-user friendly exception
-                throw new CheckoutException(\__(
+                throw new CheckoutException(__(
                     'Error while cancelling order. Please contact customer support with order id: %id to release discount coupons.',
                     [ 'id'=> $orderId ]
                 ));

--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -549,7 +549,21 @@ class ReceiptDataProvider
     private function cancelOrderById($orderId): void
     {
         if ($this->gatewayConfig->getCancelOrderOnFailedPayment()) {
-            $this->orderManagementInterface->cancel($orderId);
+            try {
+                $this->orderManagementInterface->cancel($orderId);
+            } catch (\Exception $e) {
+                $this->logger->critical(sprintf(
+                    'Paytrail exception during order cancel: %s,\n error trace: %s',
+                    $e->getMessage(),
+                    $e->getTraceAsString()
+                ));
+
+                // Mask and throw end-user friendly exception
+                throw new CheckoutException(\__(
+                    'Error while cancelling order. Please contact customer support with order id: %id to release discount coupons.',
+                    [ 'id'=> $orderId ]
+                ));
+            }
         }
     }
 }

--- a/i18n/fi_FI.csv
+++ b/i18n/fi_FI.csv
@@ -91,3 +91,4 @@ Hello,Hei
 "A new Paytrail Payment Service extension version is now available: ","Uusi Paytrail Payment Service -lisäosan versio saatavilla: "
 " You are running the v%1 version. We advise to update your extension."," Sinulla on käytössä versio v%1. Suosittelemme päivittämään uudemman version."
 "Paytrail Payment Service extension version %1 available!","Paytrail Payment Service -lisäosan versio %1 saatavilla!"
+"Error while cancelling order. Please contact customer support with order id: %id to release discount coupons.","Virhe tilauksen peruutuksessa. Ota yhteysasiakaspalveluun tilausnumeron %id kanssa, jotta tilauksen alennuskupongit voidaan palauttaa"


### PR DESCRIPTION
Branch introduces a simple exception catch and re-throwing a customer friendly exception that gets converted into an error message on the frontend by the controllers.

When exception happens:
prequisite:
1. Log in to magento's customer side.
2. Add water bottle to your shopping cart
3. Add coupon h20 to your shopping cart
4. go to checkout and submit your order (Nordea payment)
5. At paytrail simulate a failure to merchant.
6. MySQL foreign key exception is thrown because of Magento's coupon usage system. Despite interface stating that it will not throw exceptions.

Error has been fixed by Magento 2.4.5 but backwards compatibility should still be considered. And catching cancellation errors might be a good habbit regardless.