### PR TITLE
Fix setting callback response JSON

### DIFF
--- a/Controller/Callback/Index.php
+++ b/Controller/Callback/Index.php
@@ -56,7 +56,11 @@ class Index implements \Magento\Framework\App\ActionInterface
         if ($status == 'pending_payment' || in_array($status, Receipt::ORDER_CANCEL_STATUSES)) {
             // order status could be changed by receipt
             // if not, status change needs to be forced by processing the payment
-            $response['error'] = $this->processPayment->process($this->request->getParams(), $this->session);
+            return $response->setData(
+                [
+                    'error' => $this->processPayment->process($this->request->getParams(), $this->session)
+                ]
+            );
         }
 
         return $response;


### PR DESCRIPTION
$response is an object of type Magento\Framework\Controller\Result\Json\Interceptor, and we must use $response->setData() instead of handling it as an array.